### PR TITLE
Resolve extra recompositions on Coffee list page

### DIFF
--- a/app/src/main/java/ru/beryukhov/coffeegram/pages/CoffeeListPage.kt
+++ b/app/src/main/java/ru/beryukhov/coffeegram/pages/CoffeeListPage.kt
@@ -3,7 +3,7 @@ package ru.beryukhov.coffeegram.pages
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -91,13 +91,14 @@ private fun CoffeeList(
     onMinusClick: (coffeeType: CoffeeType) -> Unit
 ) {
     LazyColumn(modifier = modifier.fillMaxHeight()) {
-        itemsIndexed(items = coffeeItems,
-            itemContent = { _, pair: Pair<CoffeeType, Int> ->
+        items(
+            items = coffeeItems,
+            itemContent = { (type, count): Pair<CoffeeType, Int> ->
                 CoffeeTypeItem(
-                    coffeeType = pair.first,
-                    count = pair.second,
-                    onPlusClick = { onPlusClick(pair.first) },
-                    onMinusClick = { onMinusClick(pair.first) }
+                    coffeeType = type,
+                    count = count,
+                    onPlusClick = { onPlusClick(type) },
+                    onMinusClick = { onMinusClick(type) }
                 )
             })
     }

--- a/app/src/main/java/ru/beryukhov/coffeegram/pages/CoffeeListPage.kt
+++ b/app/src/main/java/ru/beryukhov/coffeegram/pages/CoffeeListPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,17 +63,18 @@ fun CoffeeListPage(
     coffeeListViewModel: CoffeeListViewModel = getViewModel<CoffeeListViewModelImpl>()
 ) {
     BackHandler { coffeeListViewModel.newIntent(NavigationIntent.ReturnToTablePage) }
-    CoffeeList(
-        coffeeItems = coffeeListViewModel.getDayCoffeesWithEmpty(localDate).toPersistentList(),
-        onPlusClick = { coffeeType: CoffeeType ->
+    val onPlusClick = remember(localDate, coffeeListViewModel) {
+        { coffeeType: CoffeeType ->
             coffeeListViewModel.newIntent(
                 DaysCoffeesIntent.PlusCoffee(
                     localDate,
                     coffeeType
                 )
             )
-        },
-        onMinusClick = { coffeeType: CoffeeType ->
+        }
+    }
+    val onMinusClick = remember(localDate, coffeeListViewModel) {
+        { coffeeType: CoffeeType ->
             coffeeListViewModel.newIntent(
                 DaysCoffeesIntent.MinusCoffee(
                     localDate,
@@ -80,6 +82,11 @@ fun CoffeeListPage(
                 )
             )
         }
+    }
+    CoffeeList(
+        coffeeItems = coffeeListViewModel.getDayCoffeesWithEmpty(localDate).toPersistentList(),
+        onPlusClick = onPlusClick,
+        onMinusClick = onMinusClick
     )
 }
 


### PR DESCRIPTION
**The Problem:** [This issue](https://github.com/phansier/Coffeegram/issues/74) speaks about unnecessary full recomposition of the coffees list after change of number in one particular item.

**The reason:** The culprits are the `onPlusClick` and `onMinusClick` lambdas passed to the `CoffeeTypeItem`. These lambdas are recreated in the `CoffeeListPage` Composable every time the list changes. As these lambdas capture unstable Classes, `LocalDate` and `CoffeeListViewModel`, the `CoffeeTypeItem` composables has to assume they changed and has to recompose.

**The solution** is to remember the lambdas, to avoid them being recreated unnecessarily.

**Is it necessary?** Probably not. Even though the recomposition of the `CoffeeTypeItem` cannot be skipped, subcomposables like Text can be skipped. The overhead of the `CoffeeTypeItem` composable is negligable. At least it should be. It appears the recomposition of the Images showing the type of coffee is not skipped. I am not sure why, since the image resources did not change. That could have a performance impact in theory. I did not further investigate.